### PR TITLE
CORE1-6453 feat: add pricefmt package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,16 @@ go 1.23
 require (
 	github.com/aws/aws-sdk-go v1.44.45
 	github.com/oklog/ulid v1.3.1
+	github.com/shopspring/decimal v1.4.0
 	github.com/sirupsen/logrus v1.8.1
+	github.com/stretchr/testify v1.6.1
 	github.com/vrischmann/envconfig v1.3.0
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,13 +10,17 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -34,6 +38,7 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pricefmt/pricefmt.go
+++ b/pricefmt/pricefmt.go
@@ -1,0 +1,164 @@
+package pricefmt
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/shopspring/decimal"
+)
+
+// Supported currency codes.
+// These constants represent the currency codes that can be used in price formatting.
+const (
+	CurrencyCodeUSD = "USD"
+	CurrencyCodeEUR = "EUR"
+	CurrencyCodeGBP = "GBP"
+	CurrencyCodeINR = "INR"
+	CurrencyCodeCAD = "CAD"
+	CurrencyCodeAUD = "AUD"
+	CurrencyCodePHP = "PHP"
+	CurrencyCodeNZD = "NZD"
+)
+
+// defaultCurrencyCode is the default currency code used when formatting prices.
+const defaultCurrencyCode = CurrencyCodeUSD
+
+// priceInput is a type constraint for price inputs that can be formatted.
+type priceInput interface {
+	~string | ~float64 | ~int | decimal.Decimal
+}
+
+// PriceFormatted holds the formatted price data, including currency and subscript information.
+type PriceFormatted struct {
+	UseSubscript      bool
+	RawValue          string
+	CurrencyCode      string
+	CurrencyString    string
+	ZerosAfterDecimal int
+	AfterZerosValue   int64
+}
+
+// TryFormat attempts to format a price with the default currency code (USD).
+// It returns nil if the formatting fails, which is useful for optional price fields.
+func TryFormat[T priceInput](price T) *PriceFormatted {
+	return TryFormatWithCurrency(price, defaultCurrencyCode)
+}
+
+// Format formats a price with the default currency code (USD).
+func Format[T priceInput](price T) (*PriceFormatted, error) {
+	return FormatWithCurrency(price, defaultCurrencyCode)
+}
+
+// TryFormatWithCurrency attempts to format a price with a specified currency code.
+func TryFormatWithCurrency[T priceInput](price T, currencyCode string) *PriceFormatted {
+	formattedPrice, err := FormatWithCurrency(price, currencyCode)
+	if err != nil {
+		return nil
+	}
+	return formattedPrice
+}
+
+// FormatWithCurrency gets formatting data for a price, primarily for handling small decimals.
+func FormatWithCurrency[T priceInput](price T, currencyCode string) (*PriceFormatted, error) {
+	dPrice, err := getDecimalValue(price)
+	if err != nil {
+		return nil, fmt.Errorf("error converting price to decimal: %w", err)
+	}
+
+	priceData := &PriceFormatted{
+		UseSubscript:   false,
+		RawValue:       dPrice.String(),
+		CurrencyCode:   currencyCode,
+		CurrencyString: getCurrencySymbol(currencyCode),
+	}
+
+	// If the price is not a small decimal, return the basic data.
+	if dPrice.IsZero() || dPrice.GreaterThanOrEqual(decimal.NewFromInt(1)) {
+		return priceData, nil
+	}
+
+	strPrice := dPrice.String()
+
+	// If the price does not contain a decimal point, it is not a small decimal.
+	// We return the basic data without subscript formatting.
+	if !strings.Contains(strPrice, ".") {
+		return priceData, nil
+	}
+
+	parts := strings.SplitN(strPrice, ".", 2)
+	wholePart := parts[0]
+	decimalPart := parts[1]
+
+	// If the whole part is not zero, we return the basic data without subscript formatting.
+	// The subscript formatting only applies to small decimals (i.e. 0.0001)
+	if wholePart != "0" {
+		return priceData, nil
+	}
+
+	leadingZeroesCount := 0
+	for _, r := range decimalPart {
+		if r == '0' {
+			leadingZeroesCount++
+		} else {
+			break
+		}
+	}
+
+	if leadingZeroesCount == 0 {
+		return priceData, nil
+	}
+
+	afterZerosValueDecimal, err := decimal.NewFromString(decimalPart[leadingZeroesCount:])
+	if err != nil {
+		return nil, fmt.Errorf("error parsing after zeros value: %w", err)
+	}
+
+	afterZerosValue := afterZerosValueDecimal.IntPart()
+
+	priceData.UseSubscript = true
+	priceData.ZerosAfterDecimal = leadingZeroesCount
+	priceData.AfterZerosValue = afterZerosValue
+
+	return priceData, nil
+}
+
+// getDecimalValue converts various types of price inputs to a decimal.Decimal.
+func getDecimalValue(price any) (decimal.Decimal, error) {
+	switch v := price.(type) {
+	case string:
+		return decimal.NewFromString(v)
+	case float64:
+		return decimal.NewFromFloat(v), nil
+	case int:
+		return decimal.NewFromInt(int64(v)), nil
+	case decimal.Decimal:
+		return v, nil
+	default:
+		return decimal.Decimal{}, fmt.Errorf("unsupported price type: %T", v)
+	}
+}
+
+// getCurrencySymbol returns the currency symbol for a given currency code.
+func getCurrencySymbol(currencyCode string) string {
+	switch currencyCode {
+	case CurrencyCodeUSD:
+		return "US$"
+	case CurrencyCodeEUR:
+		return "€"
+	case CurrencyCodeGBP:
+		return "£"
+	case CurrencyCodeINR:
+		return "₹"
+	case CurrencyCodeCAD:
+		return "CA$"
+	case CurrencyCodeAUD:
+		return "A$"
+	case CurrencyCodePHP:
+		return "₱"
+	case CurrencyCodeNZD:
+		return "NZ$"
+	default:
+		// Fallback to the code itself if unknown.
+		return currencyCode
+	}
+}

--- a/pricefmt/pricefmt_test.go
+++ b/pricefmt/pricefmt_test.go
@@ -1,0 +1,538 @@
+package pricefmt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+)
+
+// formatTestCase is a struct to hold test cases for price formatting functions.
+type formatTestCase[T priceInput] struct {
+	name         string
+	price        T // Now T, which must satisfy priceInput
+	currencyCode string
+	expected     *PriceFormatted
+	expectedErr  bool
+}
+
+// runFormatTests is a helper to reduce duplication for FormatWithCurrency and TryFormatWithCurrency tests.
+func runFormatTests[T priceInput](t *testing.T, tests []formatTestCase[T]) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test FormatWithCurrency
+			formatted, err := FormatWithCurrency(tt.price, tt.currencyCode)
+			if tt.expectedErr {
+				assert.Error(t, err, "FormatWithCurrency should return an error for invalid input")
+				assert.Nil(t, formatted, "Formatted price should be nil on error")
+			} else {
+				assert.NoError(t, err, "FormatWithCurrency should not return an error for valid input")
+				assert.NotNil(t, formatted, "Formatted price should not be nil")
+				assert.Equal(t, tt.expected.UseSubscript, formatted.UseSubscript, "UseSubscript mismatch")
+				assert.Equal(t, tt.expected.RawValue, formatted.RawValue, "RawValue mismatch")
+				assert.Equal(t, tt.expected.CurrencyCode, formatted.CurrencyCode, "CurrencyCode mismatch")
+				assert.Equal(t, tt.expected.CurrencyString, formatted.CurrencyString, "CurrencyString mismatch")
+				assert.Equal(t, tt.expected.ZerosAfterDecimal, formatted.ZerosAfterDecimal, "ZerosAfterDecimal mismatch")
+				assert.Equal(t, tt.expected.AfterZerosValue, formatted.AfterZerosValue, "AfterZerosValue mismatch")
+			}
+
+			// Test TryFormatWithCurrency
+			tryFormatted := TryFormatWithCurrency(tt.price, tt.currencyCode)
+			if tt.expectedErr {
+				assert.Nil(t, tryFormatted, "TryFormatWithCurrency should return nil for invalid input")
+			} else {
+				assert.NotNil(t, tryFormatted, "TryFormatWithCurrency should not return nil")
+				assert.Equal(t, tt.expected.UseSubscript, tryFormatted.UseSubscript, "TryFormatWithCurrency UseSubscript mismatch")
+				assert.Equal(t, tt.expected.RawValue, tryFormatted.RawValue, "TryFormatWithCurrency RawValue mismatch")
+				assert.Equal(t, tt.expected.CurrencyCode, tryFormatted.CurrencyCode, "TryFormatWithCurrency CurrencyCode mismatch")
+				assert.Equal(t, tt.expected.CurrencyString, tryFormatted.CurrencyString, "TryFormatWithCurrency CurrencyString mismatch")
+				assert.Equal(t, tt.expected.ZerosAfterDecimal, tryFormatted.ZerosAfterDecimal, "TryFormatWithCurrency ZerosAfterDecimal mismatch")
+				assert.Equal(t, tt.expected.AfterZerosValue, tryFormatted.AfterZerosValue, "TryFormatWithCurrency AfterZerosValue mismatch")
+			}
+		})
+	}
+}
+
+// runFormatDefaultCurrencyTests is a helper for Format and TryFormat tests.
+func runFormatDefaultCurrencyTests[T priceInput](t *testing.T, tests []formatTestCase[T]) {
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test Format (default currency)
+			formatted, err := Format(tt.price)
+			if tt.expectedErr {
+				assert.Error(t, err, "Format should return an error for invalid input")
+				assert.Nil(t, formatted, "Formatted price should be nil on error")
+			} else {
+				assert.NoError(t, err, "Format should not return an error for valid input")
+				assert.NotNil(t, formatted, "Formatted price should not be nil")
+				assert.Equal(t, tt.expected.UseSubscript, formatted.UseSubscript, "UseSubscript mismatch")
+				assert.Equal(t, tt.expected.RawValue, formatted.RawValue, "RawValue mismatch")
+				assert.Equal(t, tt.expected.CurrencyCode, formatted.CurrencyCode, "CurrencyCode mismatch")
+				assert.Equal(t, tt.expected.CurrencyString, formatted.CurrencyString, "CurrencyString mismatch")
+				assert.Equal(t, tt.expected.ZerosAfterDecimal, formatted.ZerosAfterDecimal, "ZerosAfterDecimal mismatch")
+				assert.Equal(t, tt.expected.AfterZerosValue, formatted.AfterZerosValue, "AfterZerosValue mismatch")
+			}
+
+			// Test TryFormat (default currency)
+			tryFormatted := TryFormat(tt.price)
+			if tt.expectedErr {
+				assert.Nil(t, tryFormatted, "TryFormat should return nil for invalid input")
+			} else {
+				assert.NotNil(t, tryFormatted, "TryFormat should not return nil")
+				assert.Equal(t, tt.expected.UseSubscript, tryFormatted.UseSubscript, "TryFormat UseSubscript mismatch")
+				assert.Equal(t, tt.expected.RawValue, tryFormatted.RawValue, "TryFormat RawValue mismatch")
+				assert.Equal(t, tt.expected.CurrencyCode, tryFormatted.CurrencyCode, "TryFormat CurrencyCode mismatch")
+				assert.Equal(t, tt.expected.CurrencyString, tryFormatted.CurrencyString, "TryFormat CurrencyString mismatch")
+				assert.Equal(t, tt.expected.ZerosAfterDecimal, tryFormatted.ZerosAfterDecimal, "TryFormat ZerosAfterDecimal mismatch")
+				assert.Equal(t, tt.expected.AfterZerosValue, tryFormatted.AfterZerosValue, "TryFormat AfterZerosValue mismatch")
+			}
+		})
+	}
+}
+
+// Test cases for int inputs
+func TestFormatWithCurrency_Int(t *testing.T) {
+	// Tests for FormatWithCurrency and TryFormatWithCurrency (explicit currency)
+	explicitCurrencyTests := []formatTestCase[int]{
+		{
+			name:         "USD integer",
+			price:        123,
+			currencyCode: CurrencyCodeUSD,
+			expected: &PriceFormatted{
+				UseSubscript:      false,
+				RawValue:          "123",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				ZerosAfterDecimal: 0,
+				AfterZerosValue:   0,
+			},
+			expectedErr: false,
+		},
+		{
+			name:         "GBP large number",
+			price:        1000000,
+			currencyCode: CurrencyCodeGBP,
+			expected: &PriceFormatted{
+				UseSubscript:      false,
+				RawValue:          "1000000",
+				CurrencyCode:      CurrencyCodeGBP,
+				CurrencyString:    "£",
+				ZerosAfterDecimal: 0,
+				AfterZerosValue:   0,
+			},
+			expectedErr: false,
+		},
+		{
+			name:         "AUD with no decimal",
+			price:        77,
+			currencyCode: CurrencyCodeAUD,
+			expected: &PriceFormatted{
+				UseSubscript:      false,
+				RawValue:          "77",
+				CurrencyCode:      CurrencyCodeAUD,
+				CurrencyString:    "A$",
+				ZerosAfterDecimal: 0,
+				AfterZerosValue:   0,
+			},
+			expectedErr: false,
+		},
+		{
+			name:         "Unsupported currency code",
+			price:        100,
+			currencyCode: "XYZ", // Unsupported
+			expected: &PriceFormatted{
+				UseSubscript:      false,
+				RawValue:          "100",
+				CurrencyCode:      "XYZ",
+				CurrencyString:    "XYZ", // Should fall back to code itself
+				ZerosAfterDecimal: 0,
+				AfterZerosValue:   0,
+			},
+			expectedErr: false,
+		},
+	}
+	runFormatTests(t, explicitCurrencyTests)
+
+	// Tests for Format and TryFormat (default USD currency)
+	defaultCurrencyTests := []formatTestCase[int]{
+		{
+			name:  "Default USD integer",
+			price: 456,
+			// For default currency functions, the expected currency is always USD
+			expected: &PriceFormatted{
+				UseSubscript:      false,
+				RawValue:          "456",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				ZerosAfterDecimal: 0,
+				AfterZerosValue:   0,
+			},
+			expectedErr: false,
+		},
+	}
+	runFormatDefaultCurrencyTests(t, defaultCurrencyTests)
+}
+
+// Test cases for float64 inputs
+func TestFormatWithCurrency_Float64(t *testing.T) {
+	// Tests for FormatWithCurrency and TryFormatWithCurrency (explicit currency)
+	explicitCurrencyTests := []formatTestCase[float64]{
+		{
+			name:         "USD float",
+			price:        123.45,
+			currencyCode: CurrencyCodeUSD,
+			expected: &PriceFormatted{
+				UseSubscript:      false,
+				RawValue:          "123.45",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				ZerosAfterDecimal: 0,
+				AfterZerosValue:   0,
+			},
+			expectedErr: false,
+		},
+		{
+			name:         "USD zero",
+			price:        0.0,
+			currencyCode: CurrencyCodeUSD,
+			expected: &PriceFormatted{
+				UseSubscript:      false,
+				RawValue:          "0",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				ZerosAfterDecimal: 0,
+				AfterZerosValue:   0,
+			},
+			expectedErr: false,
+		},
+		{
+			name:         "USD small decimal with one zero",
+			price:        0.0123,
+			currencyCode: CurrencyCodeUSD,
+			expected: &PriceFormatted{
+				UseSubscript:      true,
+				RawValue:          "0.0123",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				ZerosAfterDecimal: 1,
+				AfterZerosValue:   123,
+			},
+			expectedErr: false,
+		},
+		{
+			name:         "USD small decimal with multiple zeros",
+			price:        0.00000456,
+			currencyCode: CurrencyCodeUSD,
+			expected: &PriceFormatted{
+				UseSubscript:      true,
+				RawValue:          "0.00000456",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				ZerosAfterDecimal: 5,
+				AfterZerosValue:   456,
+			},
+			expectedErr: false,
+		},
+		{
+			name:         "USD small decimal with trailing zeros in raw value (decimal handles internally)",
+			price:        0.00100, // decimal.NewFromFloat(0.00100) will be "0.001"
+			currencyCode: CurrencyCodeUSD,
+			expected: &PriceFormatted{
+				UseSubscript:      true,
+				RawValue:          "0.001",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				ZerosAfterDecimal: 2,
+				AfterZerosValue:   1,
+			},
+			expectedErr: false,
+		},
+		{
+			name:         "USD small decimal ending in zero",
+			price:        0.00010, // decimal.NewFromFloat(0.00010) will be "0.0001"
+			currencyCode: CurrencyCodeUSD,
+			expected: &PriceFormatted{
+				UseSubscript:      true,
+				RawValue:          "0.0001",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				ZerosAfterDecimal: 3,
+				AfterZerosValue:   1,
+			},
+			expectedErr: false,
+		},
+		{
+			name:         "USD non-zero integer with decimal part, no leading zeros",
+			price:        1.0000001,
+			currencyCode: CurrencyCodeUSD,
+			expected: &PriceFormatted{
+				UseSubscript:      false,
+				RawValue:          "1.0000001",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				ZerosAfterDecimal: 0,
+				AfterZerosValue:   0,
+			},
+			expectedErr: false,
+		},
+		{
+			name:         "EUR small decimal",
+			price:        0.003,
+			currencyCode: CurrencyCodeEUR,
+			expected: &PriceFormatted{
+				UseSubscript:      true,
+				RawValue:          "0.003",
+				CurrencyCode:      CurrencyCodeEUR,
+				CurrencyString:    "€",
+				ZerosAfterDecimal: 2,
+				AfterZerosValue:   3,
+			},
+			expectedErr: false,
+		},
+		{
+			name:         "PHP small decimal from float",
+			price:        0.0000000001,
+			currencyCode: CurrencyCodePHP,
+			expected: &PriceFormatted{
+				UseSubscript:      true,
+				RawValue:          "0.0000000001",
+				CurrencyCode:      CurrencyCodePHP,
+				CurrencyString:    "₱",
+				ZerosAfterDecimal: 9,
+				AfterZerosValue:   1,
+			},
+			expectedErr: false,
+		},
+		{
+			name:         "NZD just over zero",
+			price:        0.5,
+			currencyCode: CurrencyCodeNZD,
+			expected: &PriceFormatted{
+				UseSubscript:      false,
+				RawValue:          "0.5",
+				CurrencyCode:      CurrencyCodeNZD,
+				CurrencyString:    "NZ$",
+				ZerosAfterDecimal: 0,
+				AfterZerosValue:   0,
+			},
+			expectedErr: false,
+		},
+	}
+	runFormatTests(t, explicitCurrencyTests)
+
+	// Tests for Format and TryFormat (default USD currency)
+	defaultCurrencyTests := []formatTestCase[float64]{
+		{
+			name:  "Default USD small decimal",
+			price: 0.0005,
+			expected: &PriceFormatted{
+				UseSubscript:      true,
+				RawValue:          "0.0005",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				ZerosAfterDecimal: 3,
+				AfterZerosValue:   5,
+			},
+			expectedErr: false,
+		},
+	}
+	runFormatDefaultCurrencyTests(t, defaultCurrencyTests)
+}
+
+// Test cases for string inputs
+func TestFormatWithCurrency_String(t *testing.T) {
+	// Tests for FormatWithCurrency and TryFormatWithCurrency (explicit currency)
+	explicitCurrencyTests := []formatTestCase[string]{
+		{
+			name:         "USD string",
+			price:        "123.456",
+			currencyCode: CurrencyCodeUSD,
+			expected: &PriceFormatted{
+				UseSubscript:      false,
+				RawValue:          "123.456",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				ZerosAfterDecimal: 0,
+				AfterZerosValue:   0,
+			},
+			expectedErr: false,
+		},
+		{
+			name:         "USD small decimal with string input ending in zero",
+			price:        "0.00010", // shopspring/decimal will normalize "0.00010" to "0.0001"
+			currencyCode: CurrencyCodeUSD,
+			expected: &PriceFormatted{
+				UseSubscript:      true,
+				RawValue:          "0.0001",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				ZerosAfterDecimal: 3,
+				AfterZerosValue:   1,
+			},
+			expectedErr: false,
+		},
+		{
+			name:         "CAD small decimal from string",
+			price:        "0.00005",
+			currencyCode: CurrencyCodeCAD,
+			expected: &PriceFormatted{
+				UseSubscript:      true,
+				RawValue:          "0.00005",
+				CurrencyCode:      CurrencyCodeCAD,
+				CurrencyString:    "CA$",
+				ZerosAfterDecimal: 4,
+				AfterZerosValue:   5,
+			},
+			expectedErr: false,
+		},
+		{
+			name:         "Invalid string price input",
+			price:        "invalid-price",
+			currencyCode: CurrencyCodeUSD,
+			expected:     nil,
+			expectedErr:  true,
+		},
+	}
+	runFormatTests(t, explicitCurrencyTests)
+
+	// Tests for Format and TryFormat (default USD currency)
+	defaultCurrencyTests := []formatTestCase[string]{
+		{
+			name:        "Default USD invalid string input",
+			price:       "not-a-number",
+			expected:    nil,
+			expectedErr: true,
+		},
+	}
+	runFormatDefaultCurrencyTests(t, defaultCurrencyTests)
+}
+
+// Test cases for decimal.Decimal inputs
+func TestFormatWithCurrency_Decimal(t *testing.T) {
+	// Tests for FormatWithCurrency and TryFormatWithCurrency (explicit currency)
+	explicitCurrencyTests := []formatTestCase[decimal.Decimal]{
+		{
+			name:         "USD decimal",
+			price:        decimal.NewFromFloat(987.65),
+			currencyCode: CurrencyCodeUSD,
+			expected: &PriceFormatted{
+				UseSubscript:      false,
+				RawValue:          "987.65",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				ZerosAfterDecimal: 0,
+				AfterZerosValue:   0,
+			},
+			expectedErr: false,
+		},
+		{
+			name:         "INR decimal with no fractional part",
+			price:        decimal.NewFromInt(500),
+			currencyCode: CurrencyCodeINR,
+			expected: &PriceFormatted{
+				UseSubscript:      false,
+				RawValue:          "500",
+				CurrencyCode:      CurrencyCodeINR,
+				CurrencyString:    "₹",
+				ZerosAfterDecimal: 0,
+				AfterZerosValue:   0,
+			},
+			expectedErr: false,
+		},
+	}
+	runFormatTests(t, explicitCurrencyTests)
+
+	// Tests for Format and TryFormat (default USD currency)
+	// No specific additional decimal cases needed beyond what's already covered by explicit,
+	// but keeping the structure for consistency.
+	defaultCurrencyTests := []formatTestCase[decimal.Decimal]{
+		// You might add specific default USD decimal tests here if different behavior is expected
+	}
+	runFormatDefaultCurrencyTests(t, defaultCurrencyTests)
+}
+
+// Test getDecimalValue function
+func TestGetDecimalValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       any
+		expected    decimal.Decimal
+		expectedErr bool
+	}{
+		{
+			name:        "string to decimal",
+			input:       "123.45",
+			expected:    decimal.NewFromFloat(123.45),
+			expectedErr: false,
+		},
+		{
+			name:        "float64 to decimal",
+			input:       98.76,
+			expected:    decimal.NewFromFloat(98.76),
+			expectedErr: false,
+		},
+		{
+			name:        "int to decimal",
+			input:       500,
+			expected:    decimal.NewFromInt(500),
+			expectedErr: false,
+		},
+		{
+			name:        "decimal.Decimal (no conversion)",
+			input:       decimal.NewFromFloat(1.23),
+			expected:    decimal.NewFromFloat(1.23),
+			expectedErr: false,
+		},
+		{
+			name:        "invalid string to decimal",
+			input:       "abc",
+			expected:    decimal.Decimal{},
+			expectedErr: true,
+		},
+		{
+			name:        "unsupported type (bool)",
+			input:       true,
+			expected:    decimal.Decimal{},
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := getDecimalValue(tt.input)
+			if tt.expectedErr {
+				assert.Error(t, err, "getDecimalValue should return an error")
+			} else {
+				assert.NoError(t, err, "getDecimalValue should not return an error")
+				assert.True(t, d.Equal(tt.expected), fmt.Sprintf("Expected %v, got %v", tt.expected, d))
+			}
+		})
+	}
+}
+
+// Test getCurrencySymbol function
+func TestGetCurrencySymbol(t *testing.T) {
+	tests := []struct {
+		currencyCode string
+		expected     string
+	}{
+		{CurrencyCodeUSD, "US$"},
+		{CurrencyCodeEUR, "€"},
+		{CurrencyCodeGBP, "£"},
+		{CurrencyCodeINR, "₹"},
+		{CurrencyCodeCAD, "CA$"},
+		{CurrencyCodeAUD, "A$"},
+		{CurrencyCodePHP, "₱"},
+		{CurrencyCodeNZD, "NZ$"},
+		{"UNKNOWN", "UNKNOWN"}, // Test for unsupported code
+		{"XYZ", "XYZ"},         // Another unsupported code
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("Currency: %s", tt.currencyCode), func(t *testing.T) {
+			symbol := getCurrencySymbol(tt.currencyCode)
+			assert.Equal(t, tt.expected, symbol, "Currency symbol mismatch")
+		})
+	}
+}


### PR DESCRIPTION
CHANGES DONE:
- Add `pricefmt` package for formatting small prices with currency support.

This package allows handling small prices returning a object that can be used to render the small price value using subscripts for the zeroes.

signed-off: Victor Armijo <varmijo@stocktwits.com>