### PR TITLE
feat: support negative prices in pricefmt

### DIFF
--- a/pricefmt/pricefmt_test.go
+++ b/pricefmt/pricefmt_test.go
@@ -37,6 +37,7 @@ func runFormatTests[T priceInput](t *testing.T, tests []formatTestCase[T]) {
 				assert.Equal(t, tt.expected.RawValue, formatted.RawValue, "RawValue mismatch")
 				assert.Equal(t, tt.expected.CurrencyCode, formatted.CurrencyCode, "CurrencyCode mismatch")
 				assert.Equal(t, tt.expected.CurrencyString, formatted.CurrencyString, "CurrencyString mismatch")
+				assert.Equal(t, tt.expected.IsNegative, formatted.IsNegative, "IsNegative mismatch")
 				assert.Equal(t, tt.expected.ZerosAfterDecimal, formatted.ZerosAfterDecimal, "ZerosAfterDecimal mismatch")
 				assert.Equal(t, tt.expected.AfterZerosValue, formatted.AfterZerosValue, "AfterZerosValue mismatch")
 			}
@@ -51,6 +52,7 @@ func runFormatTests[T priceInput](t *testing.T, tests []formatTestCase[T]) {
 				assert.Equal(t, tt.expected.RawValue, tryFormatted.RawValue, "TryFormatWithCurrency RawValue mismatch")
 				assert.Equal(t, tt.expected.CurrencyCode, tryFormatted.CurrencyCode, "TryFormatWithCurrency CurrencyCode mismatch")
 				assert.Equal(t, tt.expected.CurrencyString, tryFormatted.CurrencyString, "TryFormatWithCurrency CurrencyString mismatch")
+				assert.Equal(t, tt.expected.IsNegative, tryFormatted.IsNegative, "TryFormatWithCurrency IsNegative mismatch")
 				assert.Equal(t, tt.expected.ZerosAfterDecimal, tryFormatted.ZerosAfterDecimal, "TryFormatWithCurrency ZerosAfterDecimal mismatch")
 				assert.Equal(t, tt.expected.AfterZerosValue, tryFormatted.AfterZerosValue, "TryFormatWithCurrency AfterZerosValue mismatch")
 			}
@@ -74,6 +76,7 @@ func runFormatDefaultCurrencyTests[T priceInput](t *testing.T, tests []formatTes
 				assert.Equal(t, tt.expected.RawValue, formatted.RawValue, "RawValue mismatch")
 				assert.Equal(t, tt.expected.CurrencyCode, formatted.CurrencyCode, "CurrencyCode mismatch")
 				assert.Equal(t, tt.expected.CurrencyString, formatted.CurrencyString, "CurrencyString mismatch")
+				assert.Equal(t, tt.expected.IsNegative, formatted.IsNegative, "IsNegative mismatch")
 				assert.Equal(t, tt.expected.ZerosAfterDecimal, formatted.ZerosAfterDecimal, "ZerosAfterDecimal mismatch")
 				assert.Equal(t, tt.expected.AfterZerosValue, formatted.AfterZerosValue, "AfterZerosValue mismatch")
 			}
@@ -88,6 +91,7 @@ func runFormatDefaultCurrencyTests[T priceInput](t *testing.T, tests []formatTes
 				assert.Equal(t, tt.expected.RawValue, tryFormatted.RawValue, "TryFormat RawValue mismatch")
 				assert.Equal(t, tt.expected.CurrencyCode, tryFormatted.CurrencyCode, "TryFormat CurrencyCode mismatch")
 				assert.Equal(t, tt.expected.CurrencyString, tryFormatted.CurrencyString, "TryFormat CurrencyString mismatch")
+				assert.Equal(t, tt.expected.IsNegative, tryFormatted.IsNegative, "TryFormat IsNegative mismatch")
 				assert.Equal(t, tt.expected.ZerosAfterDecimal, tryFormatted.ZerosAfterDecimal, "TryFormat ZerosAfterDecimal mismatch")
 				assert.Equal(t, tt.expected.AfterZerosValue, tryFormatted.AfterZerosValue, "TryFormat AfterZerosValue mismatch")
 			}
@@ -108,6 +112,7 @@ func TestFormatWithCurrency_Int(t *testing.T) {
 				RawValue:          "123",
 				CurrencyCode:      CurrencyCodeUSD,
 				CurrencyString:    "US$",
+				IsNegative:        false,
 				ZerosAfterDecimal: nil,
 				AfterZerosValue:   nil,
 			},
@@ -122,6 +127,7 @@ func TestFormatWithCurrency_Int(t *testing.T) {
 				RawValue:          "1000000",
 				CurrencyCode:      CurrencyCodeGBP,
 				CurrencyString:    "£",
+				IsNegative:        false,
 				ZerosAfterDecimal: nil,
 				AfterZerosValue:   nil,
 			},
@@ -136,6 +142,7 @@ func TestFormatWithCurrency_Int(t *testing.T) {
 				RawValue:          "77",
 				CurrencyCode:      CurrencyCodeAUD,
 				CurrencyString:    "A$",
+				IsNegative:        false,
 				ZerosAfterDecimal: nil,
 				AfterZerosValue:   nil,
 			},
@@ -150,6 +157,7 @@ func TestFormatWithCurrency_Int(t *testing.T) {
 				RawValue:          "100",
 				CurrencyCode:      "XYZ",
 				CurrencyString:    "XYZ", // Should fall back to code itself
+				IsNegative:        false,
 				ZerosAfterDecimal: nil,
 				AfterZerosValue:   nil,
 			},
@@ -169,6 +177,7 @@ func TestFormatWithCurrency_Int(t *testing.T) {
 				RawValue:          "456",
 				CurrencyCode:      CurrencyCodeUSD,
 				CurrencyString:    "US$",
+				IsNegative:        false,
 				ZerosAfterDecimal: nil,
 				AfterZerosValue:   nil,
 			},
@@ -191,6 +200,7 @@ func TestFormatWithCurrency_Float64(t *testing.T) {
 				RawValue:          "123.45",
 				CurrencyCode:      CurrencyCodeUSD,
 				CurrencyString:    "US$",
+				IsNegative:        false,
 				ZerosAfterDecimal: nil,
 				AfterZerosValue:   nil,
 			},
@@ -205,6 +215,7 @@ func TestFormatWithCurrency_Float64(t *testing.T) {
 				RawValue:          "0",
 				CurrencyCode:      CurrencyCodeUSD,
 				CurrencyString:    "US$",
+				IsNegative:        false,
 				ZerosAfterDecimal: nil,
 				AfterZerosValue:   nil,
 			},
@@ -215,10 +226,11 @@ func TestFormatWithCurrency_Float64(t *testing.T) {
 			price:        0.0123,
 			currencyCode: CurrencyCodeUSD,
 			expected: &PriceFormatted{
-				UseSubscript:      true,
+				UseSubscript:      false,
 				RawValue:          "0.0123",
 				CurrencyCode:      CurrencyCodeUSD,
 				CurrencyString:    "US$",
+				IsNegative:        false,
 				ZerosAfterDecimal: newPtr(1),
 				AfterZerosValue:   newPtr[int64](123),
 			},
@@ -233,6 +245,7 @@ func TestFormatWithCurrency_Float64(t *testing.T) {
 				RawValue:          "0.00000456",
 				CurrencyCode:      CurrencyCodeUSD,
 				CurrencyString:    "US$",
+				IsNegative:        false,
 				ZerosAfterDecimal: newPtr(5),
 				AfterZerosValue:   newPtr[int64](456),
 			},
@@ -243,10 +256,11 @@ func TestFormatWithCurrency_Float64(t *testing.T) {
 			price:        0.00100, // decimal.NewFromFloat(0.00100) will be "0.001"
 			currencyCode: CurrencyCodeUSD,
 			expected: &PriceFormatted{
-				UseSubscript:      true,
+				UseSubscript:      false,
 				RawValue:          "0.001",
 				CurrencyCode:      CurrencyCodeUSD,
 				CurrencyString:    "US$",
+				IsNegative:        false,
 				ZerosAfterDecimal: newPtr(2),
 				AfterZerosValue:   newPtr[int64](1),
 			},
@@ -257,10 +271,11 @@ func TestFormatWithCurrency_Float64(t *testing.T) {
 			price:        0.00010, // decimal.NewFromFloat(0.00010) will be "0.0001"
 			currencyCode: CurrencyCodeUSD,
 			expected: &PriceFormatted{
-				UseSubscript:      true,
+				UseSubscript:      false,
 				RawValue:          "0.0001",
 				CurrencyCode:      CurrencyCodeUSD,
 				CurrencyString:    "US$",
+				IsNegative:        false,
 				ZerosAfterDecimal: newPtr(3),
 				AfterZerosValue:   newPtr[int64](1),
 			},
@@ -275,6 +290,7 @@ func TestFormatWithCurrency_Float64(t *testing.T) {
 				RawValue:          "1.0000001",
 				CurrencyCode:      CurrencyCodeUSD,
 				CurrencyString:    "US$",
+				IsNegative:        false,
 				ZerosAfterDecimal: nil,
 				AfterZerosValue:   nil,
 			},
@@ -285,10 +301,11 @@ func TestFormatWithCurrency_Float64(t *testing.T) {
 			price:        0.003,
 			currencyCode: CurrencyCodeEUR,
 			expected: &PriceFormatted{
-				UseSubscript:      true,
+				UseSubscript:      false,
 				RawValue:          "0.003",
 				CurrencyCode:      CurrencyCodeEUR,
 				CurrencyString:    "€",
+				IsNegative:        false,
 				ZerosAfterDecimal: newPtr(2),
 				AfterZerosValue:   newPtr[int64](3),
 			},
@@ -303,6 +320,7 @@ func TestFormatWithCurrency_Float64(t *testing.T) {
 				RawValue:          "0.0000000001",
 				CurrencyCode:      CurrencyCodePHP,
 				CurrencyString:    "₱",
+				IsNegative:        false,
 				ZerosAfterDecimal: newPtr(9),
 				AfterZerosValue:   newPtr[int64](1),
 			},
@@ -317,6 +335,7 @@ func TestFormatWithCurrency_Float64(t *testing.T) {
 				RawValue:          "0.5",
 				CurrencyCode:      CurrencyCodeNZD,
 				CurrencyString:    "NZ$",
+				IsNegative:        false,
 				ZerosAfterDecimal: nil,
 				AfterZerosValue:   nil,
 			},
@@ -331,10 +350,11 @@ func TestFormatWithCurrency_Float64(t *testing.T) {
 			name:  "Default USD small decimal",
 			price: 0.0005,
 			expected: &PriceFormatted{
-				UseSubscript:      true,
+				UseSubscript:      false,
 				RawValue:          "0.0005",
 				CurrencyCode:      CurrencyCodeUSD,
 				CurrencyString:    "US$",
+				IsNegative:        false,
 				ZerosAfterDecimal: newPtr(3),
 				AfterZerosValue:   newPtr[int64](5),
 			},
@@ -357,6 +377,7 @@ func TestFormatWithCurrency_String(t *testing.T) {
 				RawValue:          "123.456",
 				CurrencyCode:      CurrencyCodeUSD,
 				CurrencyString:    "US$",
+				IsNegative:        false,
 				ZerosAfterDecimal: nil,
 				AfterZerosValue:   nil,
 			},
@@ -367,10 +388,11 @@ func TestFormatWithCurrency_String(t *testing.T) {
 			price:        "0.00010", // shopspring/decimal will normalize "0.00010" to "0.0001"
 			currencyCode: CurrencyCodeUSD,
 			expected: &PriceFormatted{
-				UseSubscript:      true,
+				UseSubscript:      false,
 				RawValue:          "0.0001",
 				CurrencyCode:      CurrencyCodeUSD,
 				CurrencyString:    "US$",
+				IsNegative:        false,
 				ZerosAfterDecimal: newPtr(3),
 				AfterZerosValue:   newPtr[int64](1),
 			},
@@ -381,10 +403,11 @@ func TestFormatWithCurrency_String(t *testing.T) {
 			price:        "0.00005",
 			currencyCode: CurrencyCodeCAD,
 			expected: &PriceFormatted{
-				UseSubscript:      true,
+				UseSubscript:      false,
 				RawValue:          "0.00005",
 				CurrencyCode:      CurrencyCodeCAD,
 				CurrencyString:    "CA$",
+				IsNegative:        false,
 				ZerosAfterDecimal: newPtr(4),
 				AfterZerosValue:   newPtr[int64](5),
 			},
@@ -425,6 +448,7 @@ func TestFormatWithCurrency_Decimal(t *testing.T) {
 				RawValue:          "987.65",
 				CurrencyCode:      CurrencyCodeUSD,
 				CurrencyString:    "US$",
+				IsNegative:        false,
 				ZerosAfterDecimal: nil,
 				AfterZerosValue:   nil,
 			},
@@ -439,6 +463,7 @@ func TestFormatWithCurrency_Decimal(t *testing.T) {
 				RawValue:          "500",
 				CurrencyCode:      CurrencyCodeINR,
 				CurrencyString:    "₹",
+				IsNegative:        false,
 				ZerosAfterDecimal: nil,
 				AfterZerosValue:   nil,
 			},
@@ -537,6 +562,192 @@ func TestGetCurrencySymbol(t *testing.T) {
 		t.Run(fmt.Sprintf("Currency: %s", tt.currencyCode), func(t *testing.T) {
 			symbol := getCurrencySymbol(tt.currencyCode)
 			assert.Equal(t, tt.expected, symbol, "Currency symbol mismatch")
+		})
+	}
+}
+
+// Test cases for negative values
+func TestFormatWithCurrency_NegativeValues(t *testing.T) {
+	tests := []formatTestCase[float64]{
+		{
+			name:         "Negative integer",
+			price:        -123.0,
+			currencyCode: CurrencyCodeUSD,
+			expected: &PriceFormatted{
+				UseSubscript:      false,
+				RawValue:          "-123",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				IsNegative:        true,
+				ZerosAfterDecimal: nil,
+				AfterZerosValue:   nil,
+			},
+			expectedErr: false,
+		},
+		{
+			name:         "Negative decimal",
+			price:        -123.45,
+			currencyCode: CurrencyCodeUSD,
+			expected: &PriceFormatted{
+				UseSubscript:      false,
+				RawValue:          "-123.45",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				IsNegative:        true,
+				ZerosAfterDecimal: nil,
+				AfterZerosValue:   nil,
+			},
+			expectedErr: false,
+		},
+		{
+			name:         "Negative small decimal",
+			price:        -0.00000456,
+			currencyCode: CurrencyCodeUSD,
+			expected: &PriceFormatted{
+				UseSubscript:      true,
+				RawValue:          "-0.00000456",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				IsNegative:        true,
+				ZerosAfterDecimal: newPtr(5),
+				AfterZerosValue:   newPtr[int64](456),
+			},
+			expectedErr: false,
+		},
+		{
+			name:         "Negative small decimal with different currency",
+			price:        -0.0001,
+			currencyCode: CurrencyCodeEUR,
+			expected: &PriceFormatted{
+				UseSubscript:      false,
+				RawValue:          "-0.0001",
+				CurrencyCode:      CurrencyCodeEUR,
+				CurrencyString:    "€",
+				IsNegative:        true,
+				ZerosAfterDecimal: newPtr(3),
+				AfterZerosValue:   newPtr[int64](1),
+			},
+			expectedErr: false,
+		},
+	}
+	runFormatTests(t, tests)
+}
+
+// Test cases for FormatWithOptions function
+func TestFormatWithOptions(t *testing.T) {
+	tests := []struct {
+		name            string
+		price           float64
+		currencyCode    string
+		subscriptLength int
+		valueLength     int
+		expected        *PriceFormatted
+		expectedErr     bool
+	}{
+		{
+			name:            "Custom subscript length - should use subscript with 3 zeros",
+			price:           0.000123,
+			currencyCode:    CurrencyCodeUSD,
+			subscriptLength: 3,
+			valueLength:     4,
+			expected: &PriceFormatted{
+				UseSubscript:      true,
+				RawValue:          "0.000123",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				IsNegative:        false,
+				ZerosAfterDecimal: newPtr(3),
+				AfterZerosValue:   newPtr[int64](123),
+			},
+			expectedErr: false,
+		},
+		{
+			name:            "Custom subscript length - should NOT use subscript with only 2 zeros",
+			price:           0.000123,
+			currencyCode:    CurrencyCodeUSD,
+			subscriptLength: 4, // Requires 4+ zeros, but we only have 3
+			valueLength:     4,
+			expected: &PriceFormatted{
+				UseSubscript:      false,
+				RawValue:          "0.000123",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				IsNegative:        false,
+				ZerosAfterDecimal: newPtr(3),
+				AfterZerosValue:   newPtr[int64](123),
+			},
+			expectedErr: false,
+		},
+		{
+			name:            "Custom value length - should truncate to 2 digits",
+			price:           0.000001234,
+			currencyCode:    CurrencyCodeUSD,
+			subscriptLength: 5,
+			valueLength:     2,
+			expected: &PriceFormatted{
+				UseSubscript:      true,
+				RawValue:          "0.000001234",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				IsNegative:        false,
+				ZerosAfterDecimal: newPtr(5),
+				AfterZerosValue:   newPtr[int64](12), // Truncated from 1234 to 12
+			},
+			expectedErr: false,
+		},
+		{
+			name:            "Custom value length - should truncate to 1 digit",
+			price:           0.000001234,
+			currencyCode:    CurrencyCodeUSD,
+			subscriptLength: 5,
+			valueLength:     1,
+			expected: &PriceFormatted{
+				UseSubscript:      true,
+				RawValue:          "0.000001234",
+				CurrencyCode:      CurrencyCodeUSD,
+				CurrencyString:    "US$",
+				IsNegative:        false,
+				ZerosAfterDecimal: newPtr(5),
+				AfterZerosValue:   newPtr[int64](1), // Truncated from 1234 to 1
+			},
+			expectedErr: false,
+		},
+		{
+			name:            "Negative value with custom options",
+			price:           -0.000456,
+			currencyCode:    CurrencyCodeEUR,
+			subscriptLength: 3,
+			valueLength:     2,
+			expected: &PriceFormatted{
+				UseSubscript:      true,
+				RawValue:          "-0.000456",
+				CurrencyCode:      CurrencyCodeEUR,
+				CurrencyString:    "€",
+				IsNegative:        true,
+				ZerosAfterDecimal: newPtr(3),
+				AfterZerosValue:   newPtr[int64](45), // Truncated from 456 to 45
+			},
+			expectedErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatted, err := FormatWithOptions(tt.price, tt.currencyCode, tt.subscriptLength, tt.valueLength)
+			if tt.expectedErr {
+				assert.Error(t, err, "FormatWithOptions should return an error for invalid input")
+				assert.Nil(t, formatted, "Formatted price should be nil on error")
+			} else {
+				assert.NoError(t, err, "FormatWithOptions should not return an error for valid input")
+				assert.NotNil(t, formatted, "Formatted price should not be nil")
+				assert.Equal(t, tt.expected.UseSubscript, formatted.UseSubscript, "UseSubscript mismatch")
+				assert.Equal(t, tt.expected.RawValue, formatted.RawValue, "RawValue mismatch")
+				assert.Equal(t, tt.expected.CurrencyCode, formatted.CurrencyCode, "CurrencyCode mismatch")
+				assert.Equal(t, tt.expected.CurrencyString, formatted.CurrencyString, "CurrencyString mismatch")
+				assert.Equal(t, tt.expected.IsNegative, formatted.IsNegative, "IsNegative mismatch")
+				assert.Equal(t, tt.expected.ZerosAfterDecimal, formatted.ZerosAfterDecimal, "ZerosAfterDecimal mismatch")
+				assert.Equal(t, tt.expected.AfterZerosValue, formatted.AfterZerosValue, "AfterZerosValue mismatch")
+			}
 		})
 	}
 }


### PR DESCRIPTION
CHANGES DONE:
- Updated pricefmt to handle negative prices correctly.
- Added parameters to set the number of leading zeros required to trigger subscript formatting.
- Added parameters to set the number of decimal places to show after leading zeros in subscript formatting

signed-off: Victor Armijo <varmijo@stocktwits.com>